### PR TITLE
Hide marquee on mobile

### DIFF
--- a/css/styles.css
+++ b/css/styles.css
@@ -275,6 +275,10 @@ li {
 /*** Mobile ***/
 @media (max-width: 990px) {
 
+    marquee {
+        display: none;
+    }
+
     .heading-float {
         padding-top: 6rem;        
     }


### PR DESCRIPTION
Marquee is not smooth on mobile. Remove for now on smaller screens.